### PR TITLE
Install the skill for Codex CLI as well as Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,34 @@ per-problem transcripts, and every honest limitation:
 
 ## Install
 
-One line, no clone, no build step of your own — drops the skill straight
-into `~/.claude/skills/neuroarxiv`:
+One line, no clone, no build step of your own:
 
 ```bash
 npx github:UditAkhourii/neuroarxiv install
 ```
 
-Restart Claude Code (or start a new session) and `/neuroarxiv "<problem>"`
-is live.
+Works for **Claude Code and Codex CLI**. Both discover skills at
+`<agent home>/skills/<name>/SKILL.md` and read the same frontmatter, so one
+bundled skill serves both — with no flag, `install` picks whichever agents are
+actually present on your machine.
+
+| Target | Flag | Lands in |
+| --- | --- | --- |
+| Claude Code | `--claude` | `~/.claude/skills/neuroarxiv` |
+| Codex CLI | `--codex` | `~/.codex/skills/neuroarxiv` |
+| Both | `--all` | both, whether or not they're detected |
+
+Pin a target explicitly when you want it installed regardless of detection:
+
+```bash
+npx github:UditAkhourii/neuroarxiv install --codex
+```
+
+`CLAUDE_CONFIG_DIR` and `CODEX_HOME` are honoured if you keep those directories
+somewhere non-default.
+
+Restart the agent (or start a new session) and NeuroArxiv is live — in Claude
+Code as `/neuroarxiv "<problem>"`, in Codex by asking for it by name.
 
 <details>
 <summary>Prefer a full local checkout (editing the engine, running the CLI directly, contributing)?</summary>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,34 +4,37 @@
 // Usage:
 //   neuroarxiv "how should I cache LLM completions across requests?"
 //   neuroarxiv "..." --categories cs.DB,cs.DC --papers 5 --json > result.json
-//   neuroarxiv install    (drop the skill into ~/.claude/skills/neuroarxiv)
+//   neuroarxiv install            (install for every agent detected on this machine)
+//   neuroarxiv install --codex    (install for Codex CLI only)
 
-import { readFileSync, statSync, mkdirSync, copyFileSync, existsSync } from "node:fs";
-import { homedir } from "node:os";
+import { readFileSync, statSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { run } from "./engine.js";
 import { renderText } from "./render.js";
+import { AGENT_IDS, installSkill, type AgentId } from "./install.js";
 import type { RunEvent, RunOptions } from "./types.js";
 
 // Package root is one level up from dist/cli.js (or src/cli.ts under tsx).
 const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-function installSkill(): void {
-  const source = join(PACKAGE_ROOT, "skills", "neuroarxiv", "SKILL.md");
-  if (!existsSync(source)) {
-    console.error(`Error: couldn't find the bundled SKILL.md at ${source}`);
-    console.error("This usually means the package wasn't installed with its skills/ directory intact.");
-    process.exit(1);
+/** Parse `install` sub-flags: --claude, --codex, --all. No flags = auto-detect. */
+function parseInstallTargets(argv: string[]): AgentId[] {
+  const requested: AgentId[] = [];
+  for (const arg of argv) {
+    if (arg === "--all") {
+      requested.push(...AGENT_IDS);
+      continue;
+    }
+    const id = AGENT_IDS.find((candidate) => arg === `--${candidate}`);
+    if (!id) {
+      console.error(`Error: unknown flag for \`install\`: ${arg}`);
+      console.error(`Supported: ${AGENT_IDS.map((a) => `--${a}`).join(", ")}, --all`);
+      process.exit(1);
+    }
+    requested.push(id);
   }
-
-  const targetDir = join(homedir(), ".claude", "skills", "neuroarxiv");
-  const target = join(targetDir, "SKILL.md");
-  mkdirSync(targetDir, { recursive: true });
-  copyFileSync(source, target);
-
-  console.log(`✓ Installed the neuroarxiv skill to ${target}`);
-  console.log(`  Restart Claude Code (or start a new session) and run /neuroarxiv "<problem>".`);
+  return [...new Set(requested)];
 }
 
 type Flags = {
@@ -107,8 +110,16 @@ function printHelp() {
   first step and known prior-art pitfalls to avoid — instead of a shortlist.
 
 USAGE
-  neuroarxiv install         drop the skill into ~/.claude/skills/neuroarxiv
+  neuroarxiv install [target]  drop the skill into a local agent's skills directory
   neuroarxiv "<problem>" [flags]
+
+INSTALL TARGETS
+  (none)                 install for every agent detected on this machine
+  --claude               Claude Code   → ~/.claude/skills/neuroarxiv
+  --codex                Codex CLI     → ~/.codex/skills/neuroarxiv
+  --all                  both, whether or not they're detected
+
+  Honours CLAUDE_CONFIG_DIR and CODEX_HOME if you keep those elsewhere.
 
 FLAGS
   --categories A,B      pin arXiv category ids instead of auto-detecting
@@ -132,7 +143,9 @@ EXAMPLES
 
 async function main() {
   if (process.argv[2] === "install") {
-    installSkill();
+    const requested = parseInstallTargets(process.argv.slice(3));
+    const code = installSkill({ packageRoot: PACKAGE_ROOT, requested });
+    if (code !== 0) process.exit(code);
     return;
   }
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,0 +1,144 @@
+// Installs the bundled skill into a local coding agent's skills directory.
+//
+// Claude Code and Codex CLI both discover skills at `<agent home>/skills/<name>/SKILL.md`
+// and read the same YAML frontmatter (`name`, `description`), so one bundled copy serves
+// both — only the agent home differs. That is why this installs by copying the skill
+// directory verbatim rather than rewriting anything per target.
+
+import { cpSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const SKILL_NAME = "neuroarxiv";
+
+export type AgentId = "claude" | "codex";
+
+export const AGENT_IDS: readonly AgentId[] = ["claude", "codex"] as const;
+
+export type AgentTarget = {
+  id: AgentId;
+  label: string;
+  /** Agent config root, e.g. ~/.claude — also the presence check for auto-detection. */
+  home: string;
+  /** Where the skill directory lands, e.g. ~/.claude/skills/neuroarxiv */
+  installDir: string;
+  /** Printed after a successful install for this target. */
+  activation: string;
+};
+
+/**
+ * Resolve one agent's paths. `env` and `home` are injectable so this stays pure and testable.
+ * CLAUDE_CONFIG_DIR / CODEX_HOME are the agents' own overrides for a non-default config root.
+ */
+export function agentTarget(
+  id: AgentId,
+  env: Record<string, string | undefined> = process.env,
+  home: string = homedir(),
+): AgentTarget {
+  const spec =
+    id === "claude"
+      ? {
+          label: "Claude Code",
+          home: env.CLAUDE_CONFIG_DIR || join(home, ".claude"),
+          activation: `Restart Claude Code (or start a new session), then run /${SKILL_NAME} "<problem>".`,
+        }
+      : {
+          label: "Codex CLI",
+          home: env.CODEX_HOME || join(home, ".codex"),
+          activation: `Start a new Codex session — the skill loads from its description, or ask for ${SKILL_NAME} by name.`,
+        };
+
+  return {
+    id,
+    label: spec.label,
+    home: spec.home,
+    installDir: join(spec.home, "skills", SKILL_NAME),
+    activation: spec.activation,
+  };
+}
+
+export function allAgentTargets(
+  env?: Record<string, string | undefined>,
+  home?: string,
+): AgentTarget[] {
+  return AGENT_IDS.map((id) => agentTarget(id, env, home));
+}
+
+export type Resolution = {
+  selected: AgentTarget[];
+  /** True when nothing was requested explicitly and we picked based on what's on disk. */
+  autoDetected: boolean;
+  /** Set when auto-detection found no agent and we fell back to a default. */
+  fellBack: boolean;
+};
+
+/**
+ * Pick install targets. Explicit request wins. Otherwise install to every agent that is
+ * actually present on this machine, so `install` does the right thing for people running
+ * one agent, the other, or both. With neither present we still install for Claude Code —
+ * preserving the original behaviour for a fresh machine rather than failing.
+ */
+export function resolveTargets(
+  requested: readonly AgentId[],
+  targets: readonly AgentTarget[] = allAgentTargets(),
+  exists: (path: string) => boolean = existsSync,
+): Resolution {
+  if (requested.length > 0) {
+    const wanted = new Set(requested);
+    return { selected: targets.filter((t) => wanted.has(t.id)), autoDetected: false, fellBack: false };
+  }
+
+  const detected = targets.filter((t) => exists(t.home));
+  if (detected.length > 0) return { selected: detected, autoDetected: true, fellBack: false };
+
+  return {
+    selected: targets.filter((t) => t.id === "claude"),
+    autoDetected: true,
+    fellBack: true,
+  };
+}
+
+export type InstallOptions = {
+  packageRoot: string;
+  requested: readonly AgentId[];
+  log?: (message: string) => void;
+  logError?: (message: string) => void;
+};
+
+/** Returns a process exit code: 0 on success, 1 if the bundled skill is missing. */
+export function installSkill(opts: InstallOptions): number {
+  const { packageRoot, requested } = opts;
+  const log = opts.log ?? console.log;
+  const logError = opts.logError ?? console.error;
+
+  const source = join(packageRoot, "skills", SKILL_NAME);
+  if (!existsSync(join(source, "SKILL.md"))) {
+    logError(`Error: couldn't find the bundled SKILL.md at ${join(source, "SKILL.md")}`);
+    logError("This usually means the package wasn't installed with its skills/ directory intact.");
+    return 1;
+  }
+
+  const { selected, autoDetected, fellBack } = resolveTargets(requested);
+
+  for (const target of selected) {
+    mkdirSync(target.installDir, { recursive: true });
+    // Copy the whole skill directory, not just SKILL.md, so bundled references/ come along.
+    cpSync(source, target.installDir, { recursive: true });
+    log(`✓ Installed the ${SKILL_NAME} skill for ${target.label} → ${join(target.installDir, "SKILL.md")}`);
+    log(`  ${target.activation}`);
+  }
+
+  if (fellBack) {
+    log("");
+    log("  Note: no agent config directory was found, so this defaulted to Claude Code.");
+    log(`  Run \`${SKILL_NAME} install --codex\` to install for Codex CLI instead.`);
+  } else if (autoDetected && selected.length === 1) {
+    const missing = AGENT_IDS.filter((id) => !selected.some((t) => t.id === id));
+    for (const id of missing) {
+      log("");
+      log(`  ${agentTarget(id).label} wasn't detected. Install for it anyway with \`${SKILL_NAME} install --${id}\`.`);
+    }
+  }
+
+  return 0;
+}

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { join } from "node:path";
+
+import { agentTarget, allAgentTargets, resolveTargets } from "../src/install.ts";
+
+const HOME = "/home/dev";
+const noEnv = {};
+
+test("both agents install to the same <home>/skills/<name>/SKILL.md shape", () => {
+  const claude = agentTarget("claude", noEnv, HOME);
+  const codex = agentTarget("codex", noEnv, HOME);
+
+  assert.equal(claude.installDir, join(HOME, ".claude", "skills", "neuroarxiv"));
+  assert.equal(codex.installDir, join(HOME, ".codex", "skills", "neuroarxiv"));
+});
+
+test("CLAUDE_CONFIG_DIR and CODEX_HOME override the default agent home", () => {
+  const env = { CLAUDE_CONFIG_DIR: "/cfg/claude", CODEX_HOME: "/cfg/codex" };
+
+  assert.equal(agentTarget("claude", env, HOME).installDir, "/cfg/claude/skills/neuroarxiv");
+  assert.equal(agentTarget("codex", env, HOME).installDir, "/cfg/codex/skills/neuroarxiv");
+});
+
+test("an explicit request wins over what is present on disk", () => {
+  const targets = allAgentTargets(noEnv, HOME);
+  const { selected, autoDetected } = resolveTargets(["codex"], targets, () => true);
+
+  assert.deepEqual(selected.map((t) => t.id), ["codex"]);
+  assert.equal(autoDetected, false);
+});
+
+test("with no request, installs for every agent present on this machine", () => {
+  const targets = allAgentTargets(noEnv, HOME);
+  const { selected, autoDetected, fellBack } = resolveTargets([], targets, () => true);
+
+  assert.deepEqual(selected.map((t) => t.id), ["claude", "codex"]);
+  assert.equal(autoDetected, true);
+  assert.equal(fellBack, false);
+});
+
+test("with only Codex present, Claude Code is not installed for", () => {
+  const targets = allAgentTargets(noEnv, HOME);
+  const codexOnly = (path: string) => path === join(HOME, ".codex");
+  const { selected, fellBack } = resolveTargets([], targets, codexOnly);
+
+  assert.deepEqual(selected.map((t) => t.id), ["codex"]);
+  assert.equal(fellBack, false);
+});
+
+test("with no agent present, falls back to Claude Code rather than installing nothing", () => {
+  const targets = allAgentTargets(noEnv, HOME);
+  const { selected, fellBack } = resolveTargets([], targets, () => false);
+
+  assert.deepEqual(selected.map((t) => t.id), ["claude"]);
+  assert.equal(fellBack, true);
+});


### PR DESCRIPTION
## What

`install` hardcoded `~/.claude/skills/neuroarxiv`, so Codex CLI users had no path to the skill short of copying it by hand.

It turns out no per-target work is needed: **Codex CLI discovers skills at the same `<agent home>/skills/<name>/SKILL.md` path as Claude Code, and reads the same YAML frontmatter.** Only the agent home differs, so one bundled skill already serves both.

## Behaviour

`install` with no flags now installs for **every agent it detects** on the machine — the common case needs no new knowledge:

```bash
npx github:UditAkhourii/neuroarxiv install
```

| Target | Flag | Lands in |
| --- | --- | --- |
| Claude Code | `--claude` | `~/.claude/skills/neuroarxiv` |
| Codex CLI | `--codex` | `~/.codex/skills/neuroarxiv` |
| Both | `--all` | both, whether or not they're detected |

- Explicit flags override detection, for installing ahead of an agent you haven't set up yet.
- `CLAUDE_CONFIG_DIR` and `CODEX_HOME` are honoured for non-default config roots.
- With **neither** agent present it still installs for Claude Code, preserving the previous behaviour on a fresh machine.
- Unknown flags exit 1 with the supported list rather than silently installing somewhere unexpected.

## Changes

- **`src/install.ts`** (new) — target resolution and install. Pure over an injected `env` / `home` / `exists`, which is what makes it testable without touching a real home directory.
- **`src/cli.ts`** — flag parsing and help; install logic moves out.
- **`tests/install.test.ts`** (new) — 6 tests covering path shape, env overrides, explicit-request precedence, both-detected, one-detected, and the no-agent fallback.
- **`README.md`** — install section.

One incidental fix: the copy is now recursive over the skill directory rather than `SKILL.md` alone, so any bundled `references/` come along.

## Verification

Full CI sequence green locally — `npm run typecheck`, **13/13 tests**, `npm run build`, `node dist/cli.js --help`, `npm pack --dry-run` (picks up `dist/install.js`).

Plus four end-to-end runs against a sandboxed home via `CLAUDE_CONFIG_DIR` / `CODEX_HOME`, so nothing touched a real config dir:

1. Codex present, Claude absent → installs for Codex only, notes how to add Claude
2. Both present → installs for both
3. Explicit `--codex` with neither present → installs for Codex
4. `--gemini` → exits 1 with the supported flag list

No changes to the engine, the arXiv fetch path, or the skill content itself.